### PR TITLE
Enable status support in sealed secrets

### DIFF
--- a/sealed-secrets-operator/base/bitnami-sealed-secrets.yaml
+++ b/sealed-secrets-operator/base/bitnami-sealed-secrets.yaml
@@ -29,7 +29,9 @@ spec:
       - args: []
         command:
         - controller
-        env: []
+        env:
+        - name: SEALED_SECRETS_UPDATE_STATUS
+          value: '1'
         image: quay.io/bitnami/sealed-secrets-controller:v0.12.6
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
Add support for status field in sealed-secrets. This makes it much easier to understand the status of the secret plus can be used by ArgoCD to fail sealed-secrets that failed.