### PR TITLE
Make authz configurable by moving sar to env variable

### DIFF
--- a/grafana-operator/base/instance/grafana.yaml
+++ b/grafana-operator/base/instance/grafana.yaml
@@ -15,14 +15,17 @@ spec:
     auth.anonymous:
       enabled: True
   containers:
-    - args:
+    - env:
+      - name: SAR
+        value: '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+      args:
         - '-provider=openshift'
         - '-pass-basic-auth=false'
         - '-https-address=:9091'
         - '-http-address='
         - '-email-domain=*'
         - '-upstream=http://localhost:3000'
-        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - "$(SAR)"
         - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
         - '-tls-cert=/etc/tls/private/tls.crt'
         - '-tls-key=/etc/tls/private/tls.key'


### PR DESCRIPTION
Enable grafana authorization to be configurable by moving sar into an environment variable. See here for more details on oauth-proxy and subject access review (sar).

https://github.com/openshift/oauth-proxy#limiting-access-to-users