### PR TITLE
substitute the content of the SA with the proper definition instead of job.yaml

### DIFF
--- a/letsencrypt-certs/base/job-serviceaccount.yaml
+++ b/letsencrypt-certs/base/job-serviceaccount.yaml
@@ -1,37 +1,4 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: letsencrypt-certificates-job
-  namespace: letsencrypt-job
-spec:
-  template:
-    spec:
-      containers:
-        - image: quay.io/pittar/oc-acme:latest
-          env:
-            - name: STAGING
-              value: 'false'
-            - name: PATCH_API_SERVER
-              value: 'true'
-            - name: PATCH_API_SERVER
-              value: 'false'
-          envFrom:
-            - secretRef:
-                name: cloud-dns-credentials
-          command:
-            - /bin/bash
-            - -c
-            - |
-              #!/usr/bin/env bash
-
-              /scripts/aws.sh
-
-              echo "Done!"
-
-          imagePullPolicy: Always
-          name: letsencrypt-certificates-job
-      dnsPolicy: ClusterFirst
-      restartPolicy: Never
-      serviceAccount: letsencrypt-job-sa
-      serviceAccountName: letsencrypt-job-sa
-      terminationGracePeriodSeconds: 30
+    name: letsencrypt-job-sa


### PR DESCRIPTION
Testing the letsencrypt-certs kustomization, I received an error:

```
oc apply -k letsencrypt-certs/base
error: rawResources failed to read Resources: id '"batch_v1_Job|letsencrypt-job|~P|letsencrypt-certificates-job|~S"' already used
```

I check the job.yaml and the job-serviceaccount.yaml and are the same file, I suppose that this is a wrong file. Instead I changed the SA for the proper one referred in the @pittar personal ocp-letsencrypt-job repo.

After testing worked like a charm:

```
 oc apply -k letsencrypt-certs/base
namespace/letsencrypt-job unchanged
serviceaccount/letsencrypt-job-sa created
clusterrole.rbac.authorization.k8s.io/letsencrypt-certs-clusterrole unchanged
clusterrole.rbac.authorization.k8s.io/letsencrypt-ingresscontroller-clusterrole unchanged
clusterrolebinding.rbac.authorization.k8s.io/letsencrypt-certs-manager created
clusterrolebinding.rbac.authorization.k8s.io/letsencrypt-cluster-admin created
clusterrolebinding.rbac.authorization.k8s.io/letsencrypt-ingresscontroller-patcher created
job.batch/letsencrypt-certificates-job unchanged
sealedsecret.bitnami.com/cloud-dns-credentials unchanged
```

```
$ oc get sa -n letsencrypt-job | grep let
letsencrypt-job-sa   2         3m12s
```