### PR TITLE
Installplan subscription fix

### DIFF
--- a/installplan-approver/README.md
+++ b/installplan-approver/README.md
@@ -1,3 +1,27 @@
 # Install Plan Approver
 
 In OCP 4 when you set an operator for manual upgrades you need to manually approve the initial deployment which is challenging in a gitops world. The installplan-approver-job created by Andrew Pitt can be used to approve all pending installplans in the namespace in which it is deployed.
+
+## Usage
+
+If you have cloned the `catalog` repository, you can install the installplan-approver job based on the overlay of your choice by running from the root `catalog` directory
+
+```
+oc apply -k installplan-approval/base
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-canada-gitops/catalog/installplan-approval/base
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - github.com/redhat-canada-gitops/catalog/installplan-approval/base?ref=master
+```

--- a/installplan-approver/base/installplan-approver-job.yaml
+++ b/installplan-approver/base/installplan-approver-job.yaml
@@ -16,7 +16,7 @@ spec:
 
               echo "Approving operator install.  Waiting a few seconds to make sure the InstallPlan gets created first."
               sleep $SLEEP
-              for subscription in `oc get subscription -o jsonpath='{.items[0].metadata.name}'`
+              for subscription in `oc get subscriptions.operators.coreos.com -o jsonpath='{.items[0].metadata.name}'`
               do
                 echo "Processing subscription '$subscription'"
 


### PR DESCRIPTION
There is a name conflict for `subscriptions` between operators and knative:

subscriptions.messaging.knative.dev
subscriptions.operators.coreos.com 

This update makes the `oc get subscription` more specific if the cluster has knative installed on it.

I also added some usage docs because why not.