### PR TITLE
Update jaeger operator overlays

### DIFF
--- a/jaeger-operator/base/kustomization.yaml
+++ b/jaeger-operator/base/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: openshift-operators
+
 resources:
 - jaeger-subscription.yaml

--- a/jaeger-operator/overlays/1.17-stable/README.md
+++ b/jaeger-operator/overlays/1.17-stable/README.md
@@ -1,0 +1,3 @@
+Installs the *1.17-stable* channel version of the OpenShift Jaeger Operator
+
+**Version: 1.17.8**

--- a/jaeger-operator/overlays/1.17-stable/kustomization.yaml
+++ b/jaeger-operator/overlays/1.17-stable/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+- target:
+    group: operators.coreos.com
+    version: v1alpha1
+    kind: Subscription
+    name: jaeger-product
+    namespace: openshift-operators
+  path: patch-channel-and-version.yaml

--- a/jaeger-operator/overlays/1.17-stable/patch-channel-and-version.yaml
+++ b/jaeger-operator/overlays/1.17-stable/patch-channel-and-version.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/channel
+  value: '1.17-stable'
+- op: replace
+  path: /spec/startingCSV
+  value: jaeger-operator.v1.17.8

--- a/jaeger-operator/overlays/1.20-stable/README.md
+++ b/jaeger-operator/overlays/1.20-stable/README.md
@@ -1,0 +1,3 @@
+Installs the *1.20-stable* channel version of the OpenShift Jaeger Operator
+
+**Version: 1.20.3**

--- a/jaeger-operator/overlays/1.20-stable/kustomization.yaml
+++ b/jaeger-operator/overlays/1.20-stable/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+- target:
+    group: operators.coreos.com
+    version: v1alpha1
+    kind: Subscription
+    name: jaeger-product
+    namespace: openshift-operators
+  path: patch-channel-and-version.yaml

--- a/jaeger-operator/overlays/1.20-stable/patch-channel-and-version.yaml
+++ b/jaeger-operator/overlays/1.20-stable/patch-channel-and-version.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/channel
+  value: '1.20-stable'
+- op: replace
+  path: /spec/startingCSV
+  value: jaeger-operator.v1.20.3

--- a/jaeger-operator/overlays/README.md
+++ b/jaeger-operator/overlays/README.md
@@ -1,0 +1,35 @@
+# OpenShift Jaeger Operator
+
+Installs the OpenShift Jaeger operator.
+
+Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+
+The current *overlays* available are for the following channels:
+* [1.17-stable](overlays/1.17-stable)
+* [1.20-stable](overlays/1.20-stable)
+* [stable](overlays/stable)
+* [tech-preview](overlays/tech-preview)
+
+## Usage
+
+If you have cloned the `catalog` repository, you can install the OpenShift Jaeger operator based on the overlay of your choice by running from the root `catalog` directory
+
+```
+oc apply -k jaeger-operator/overlays/<channel>
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-canada-gitops/catalog/jaeger-operator/overlays/<channel>
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - github.com/redhat-canada-gitops/catalog/jaeger-operator/overlays/<channel>?ref=master
+```

--- a/jaeger-operator/overlays/stable/README.md
+++ b/jaeger-operator/overlays/stable/README.md
@@ -1,0 +1,3 @@
+Installs the *stable* channel version of the OpenShift Jaeger Operator
+
+**Version: 1.20.3**

--- a/jaeger-operator/overlays/stable/kustomization.yaml
+++ b/jaeger-operator/overlays/stable/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+- target:
+    group: operators.coreos.com
+    version: v1alpha1
+    kind: Subscription
+    name: jaeger-product
+    namespace: openshift-operators
+  path: patch-channel-and-version.yaml

--- a/jaeger-operator/overlays/stable/patch-channel-and-version.yaml
+++ b/jaeger-operator/overlays/stable/patch-channel-and-version.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable'
+- op: replace
+  path: /spec/startingCSV
+  value: jaeger-operator.v1.20.3

--- a/jaeger-operator/overlays/tech-preview/README.md
+++ b/jaeger-operator/overlays/tech-preview/README.md
@@ -1,0 +1,3 @@
+Installs the *tech-preview* channel version of the OpenShift Jaeger Operator
+
+**Version: 2.0.0-tp.1**

--- a/jaeger-operator/overlays/tech-preview/kustomization.yaml
+++ b/jaeger-operator/overlays/tech-preview/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+- target:
+    group: operators.coreos.com
+    version: v1alpha1
+    kind: Subscription
+    name: jaeger-product
+    namespace: openshift-operators
+  path: patch-channel-and-version.yaml

--- a/jaeger-operator/overlays/tech-preview/patch-channel-and-version.yaml
+++ b/jaeger-operator/overlays/tech-preview/patch-channel-and-version.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/channel
+  value: 'tech-preview'
+- op: replace
+  path: /spec/startingCSV
+  value: jaeger-operator.v2.0.0-tp.1


### PR DESCRIPTION
Some additional updates that I would like to add to keep things more consistent with other folders but would possibly break if someone referenced the jaeger install from another repo:

- rename `jaeger-operator` -> `openshift-jaeger-operator`
- delete `jaeger-operator\overlays\default`
- update `jaeger-operator\base\jaeger-subscription.yaml` to use `patch-me-see-overlays-dir` for `channel` and `startingCSV`

Any thoughts making those updates?