### PR TITLE
update elastisearch overlays

### DIFF
--- a/elastisearch-operator/README.md
+++ b/elastisearch-operator/README.md
@@ -1,0 +1,34 @@
+# OpenShift Elastisearch Operator
+
+Installs the OpenShift Elastisearch operator.
+
+Do not use the `base` directory directly, as you will need to patch the `channel` and `version` based on the version of OpenShift you are using, or the version of the operator you want to use.
+
+The current *overlays* available are for the following channels:
+* [4.6](overlays/4.6)
+* [5.0](overlays/5.0)
+* [stable](overlays/stable)
+
+## Usage
+
+If you have cloned the `catalog` repository, you can install the OpenShift Elastisearch operator based on the overlay of your choice by running from the root `catalog` directory
+
+```
+oc apply -k elastisearch-operator/overlays/<channel>
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-canada-gitops/catalog/elastisearch-operator/overlays/<channel>
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - github.com/redhat-canada-gitops/catalog/elastisearch-operator/overlays/<channel>?ref=master
+```

--- a/elastisearch-operator/base/kustomization.yaml
+++ b/elastisearch-operator/base/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: openshift-operators-redhat
+
 resources:
 - elastisearch-subscription.yaml

--- a/elastisearch-operator/overlays/4.6/README.md
+++ b/elastisearch-operator/overlays/4.6/README.md
@@ -1,0 +1,3 @@
+Installs the *4.6* channel version of the OpenShift Elastisearch Operator
+
+**Version: 4.6.0**

--- a/elastisearch-operator/overlays/4.6/kustomization.yaml
+++ b/elastisearch-operator/overlays/4.6/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+- target:
+    group: operators.coreos.com
+    version: v1alpha1
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+  path: patch-channel-and-version.yaml

--- a/elastisearch-operator/overlays/4.6/patch-channel-and-version.yaml
+++ b/elastisearch-operator/overlays/4.6/patch-channel-and-version.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/channel
+  value: '4.6'
+- op: replace
+  path: /spec/startingCSV
+  value: elasticsearch-operator.4.6.0-202103010126.p0

--- a/elastisearch-operator/overlays/5.0/README.md
+++ b/elastisearch-operator/overlays/5.0/README.md
@@ -1,0 +1,3 @@
+Installs the *5.0* channel version of the OpenShift Elastisearch Operator
+
+**Version: 5.0.5**

--- a/elastisearch-operator/overlays/5.0/kustomization.yaml
+++ b/elastisearch-operator/overlays/5.0/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+- target:
+    group: operators.coreos.com
+    version: v1alpha1
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+  path: patch-channel-and-version.yaml

--- a/elastisearch-operator/overlays/5.0/patch-channel-and-version.yaml
+++ b/elastisearch-operator/overlays/5.0/patch-channel-and-version.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/channel
+  value: '5.0'
+- op: replace
+  path: /spec/startingCSV
+  value: elasticsearch-operator.5.0.5-11

--- a/elastisearch-operator/overlays/stable/README.md
+++ b/elastisearch-operator/overlays/stable/README.md
@@ -1,0 +1,3 @@
+Installs the *stable* channel version of the OpenShift Elastisearch Operator
+
+**Version: 5.0.5**

--- a/elastisearch-operator/overlays/stable/kustomization.yaml
+++ b/elastisearch-operator/overlays/stable/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+- target:
+    group: operators.coreos.com
+    version: v1alpha1
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+  path: patch-channel-and-version.yaml

--- a/elastisearch-operator/overlays/stable/patch-channel-and-version.yaml
+++ b/elastisearch-operator/overlays/stable/patch-channel-and-version.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/channel
+  value: 'stable'
+- op: replace
+  path: /spec/startingCSV
+  value: elasticsearch-operator.5.0.5-11


### PR DESCRIPTION
Some additional updates that I would like to make to align this with the rest of the catalog but would introduce some breaking changes if someone is referencing the repo:

- rename `elastisearch-operator` -> `openshift-elastisearch-operator`
- update `elastisearch-operator\base\elastisearch-subscription.yaml` to use `patch-me-see-overlays-dir` for `channel` and `startingCSV`

Let me know if you think those changes would be worth it!