### PR TITLE
Fix sealed-secrets-operator base url

### DIFF
--- a/sealed-secrets-operator/README.md
+++ b/sealed-secrets-operator/README.md
@@ -27,7 +27,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 # Remote base.  Use the configuration from the Red Hat Canada GitOps repo (unofficial).
 bases:
-  - github.com/redhat-canada-gitops/catalog/sealed-secrets/overlays/default
+  - github.com/redhat-canada-gitops/catalog/sealed-secrets-operator/overlays/default
 
 resources:
   - namespace.yaml


### PR DESCRIPTION
Kustomize fails to build the manifest as the folder within the `catalog` git repo is `sealed-secrets-operator` and not `sealed-secrets`

That commit changed the folder name: https://github.com/redhat-canada-gitops/catalog/commit/74ab574caf82562ba64bec1e886012f1e593b97f

Error
`Error: accumulating resources: accumulation err='accumulating resources from 'github.com/redhat-canada-gitops/catalog/sealed-secrets/overlays/default?ref=master': evalsymlink failure on '/Users/adetalhouet/tmp/ocp-gitops/apps/00-sealed-secrets/github.com/redhat-canada-gitops/catalog/sealed-secrets/overlays/default?ref=master' : lstat /Users/adetalhouet/tmp/ocp-gitops/apps/00-sealed-secrets/github.com: no such file or directory': evalsymlink failure on '/private/var/folders/p0/7r6t73s915536ksg4s9l_kwr0000gn/T/kustomize-914914193/sealed-secrets/overlays/default' : lstat /private/var/folders/p0/7r6t73s915536ksg4s9l_kwr0000gn/T/kustomize-914914193/sealed-secrets: no such file or directory`